### PR TITLE
Migrate VPP STAC Collection to STAC 1.1.0

### DIFF
--- a/schema/products/clc.json
+++ b/schema/products/clc.json
@@ -19,14 +19,20 @@
         "assets"
       ],
       "properties": {
-        "stac_version": { "const": "1.0.0" },
+        "stac_version": {
+          "const": "1.1.0"
+        },
         "stac_extensions": {
           "const": [
-            "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+            "https://stac-extensions.github.io/projection/v2.0.0/schema.json"
           ]
         },
-        "type": { "const": "Feature" },
-        "id": { "type": "string" },
+        "type": {
+          "const": "Feature"
+        },
+        "id": {
+          "type": "string"
+        },
         "bbox": {
           "type": "array",
           "minItems": 4,
@@ -34,50 +40,146 @@
           "oneOf": [
             {
               "items": [
-                { "type": "number", "minimum": -23.85, "maximum": -23.8 },
-                { "type": "number", "minimum": 24.26, "maximum": 24.31 },
-                { "type": "number", "minimum": 40.62, "maximum": 40.7 },
-                { "type": "number", "minimum": 58.89, "maximum": 59.01 }
+                {
+                  "type": "number",
+                  "minimum": -23.85,
+                  "maximum": -23.8
+                },
+                {
+                  "type": "number",
+                  "minimum": 24.26,
+                  "maximum": 24.31
+                },
+                {
+                  "type": "number",
+                  "minimum": 40.62,
+                  "maximum": 40.7
+                },
+                {
+                  "type": "number",
+                  "minimum": 58.89,
+                  "maximum": 59.01
+                }
               ]
             },
             {
               "items": [
-                { "type": "number", "minimum": -61.97, "maximum": -61.84 },
-                { "type": "number", "minimum": 15.73, "maximum": 15.76 },
-                { "type": "number", "minimum": -60.97, "maximum": -60.85 },
-                { "type": "number", "minimum": 16.58, "maximum": 16.62 }
+                {
+                  "type": "number",
+                  "minimum": -61.97,
+                  "maximum": -61.84
+                },
+                {
+                  "type": "number",
+                  "minimum": 15.73,
+                  "maximum": 15.76
+                },
+                {
+                  "type": "number",
+                  "minimum": -60.97,
+                  "maximum": -60.85
+                },
+                {
+                  "type": "number",
+                  "minimum": 16.58,
+                  "maximum": 16.62
+                }
               ]
             },
             {
               "items": [
-                { "type": "number", "minimum": -54.31, "maximum": -54.2 },
-                { "type": "number", "minimum": 3.77, "maximum": 3.78 },
-                { "type": "number", "minimum": -51.67, "maximum": -51.57 },
-                { "type": "number", "minimum": 5.85, "maximum": 5.86 }
+                {
+                  "type": "number",
+                  "minimum": -54.31,
+                  "maximum": -54.2
+                },
+                {
+                  "type": "number",
+                  "minimum": 3.77,
+                  "maximum": 3.78
+                },
+                {
+                  "type": "number",
+                  "minimum": -51.67,
+                  "maximum": -51.57
+                },
+                {
+                  "type": "number",
+                  "minimum": 5.85,
+                  "maximum": 5.86
+                }
               ]
             },
             {
               "items": [
-                { "type": "number", "minimum": -61.39, "maximum": -61.27 },
-                { "type": "number", "minimum": 14.29, "maximum": 14.32 },
-                { "type": "number", "minimum": -60.77, "maximum": -60.65 },
-                { "type": "number", "minimum": 14.95, "maximum": 14.98 }
+                {
+                  "type": "number",
+                  "minimum": -61.39,
+                  "maximum": -61.27
+                },
+                {
+                  "type": "number",
+                  "minimum": 14.29,
+                  "maximum": 14.32
+                },
+                {
+                  "type": "number",
+                  "minimum": -60.77,
+                  "maximum": -60.65
+                },
+                {
+                  "type": "number",
+                  "minimum": 14.95,
+                  "maximum": 14.98
+                }
               ]
             },
             {
               "items": [
-                { "type": "number", "minimum": 44.88, "maximum": 44.97 },
-                { "type": "number", "minimum": -13.1, "maximum": -13.08 },
-                { "type": "number", "minimum": 45.34, "maximum": 45.43 },
-                { "type": "number", "minimum": -12.56, "maximum": -12.53 }
+                {
+                  "type": "number",
+                  "minimum": 44.88,
+                  "maximum": 44.97
+                },
+                {
+                  "type": "number",
+                  "minimum": -13.1,
+                  "maximum": -13.08
+                },
+                {
+                  "type": "number",
+                  "minimum": 45.34,
+                  "maximum": 45.43
+                },
+                {
+                  "type": "number",
+                  "minimum": -12.56,
+                  "maximum": -12.53
+                }
               ]
             },
             {
               "items": [
-                { "type": "number", "minimum": 55.06, "maximum": 55.17 },
-                { "type": "number", "minimum": -21.5, "maximum": -21.45 },
-                { "type": "number", "minimum": 55.88, "maximum": 55.99 },
-                { "type": "number", "minimum": -20.81, "maximum": -20.76 }
+                {
+                  "type": "number",
+                  "minimum": 55.06,
+                  "maximum": 55.17
+                },
+                {
+                  "type": "number",
+                  "minimum": -21.5,
+                  "maximum": -21.45
+                },
+                {
+                  "type": "number",
+                  "minimum": 55.88,
+                  "maximum": 55.99
+                },
+                {
+                  "type": "number",
+                  "minimum": -20.81,
+                  "maximum": -20.76
+                }
               ]
             }
           ]
@@ -96,7 +198,9 @@
             "description": {
               "type": "string"
             },
-            "datetime": { "const": null },
+            "datetime": {
+              "const": null
+            },
             "start_datetime": {
               "type": "string",
               "pattern": "^(1986|1999|2005|2011|2017|2023)-01-01T([0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\\.[0-9]{3})?Z"
@@ -114,14 +218,19 @@
                 {
                   "name": "Copernicus Land Monitoring Service",
                   "description": "The Copernicus Land Monitoring Service provides geographical information on land cover and its changes, land use, ground motions, vegetation state, water cycle and Earth's surface energy variables to a broad range of users in Europe and across the World in the field of environmental terrestrial applications.",
-                  "roles": ["licensor", "host"],
+                  "roles": [
+                    "licensor",
+                    "host"
+                  ],
                   "url": "https://land.copernicus.eu"
                 }
               ]
             }
           }
         },
-        "collection": { "const": "corine-land-cover-raster" },
+        "collection": {
+          "const": "corine-land-cover-raster"
+        },
         "links": {
           "type": "array",
           "allOf": [
@@ -137,7 +246,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "self" }
+                  "rel": {
+                    "const": "self"
+                  }
                 }
               }
             },
@@ -145,7 +256,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "root" }
+                  "rel": {
+                    "const": "root"
+                  }
                 }
               }
             },
@@ -153,7 +266,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "parent" }
+                  "rel": {
+                    "const": "parent"
+                  }
                 }
               }
             },
@@ -161,7 +276,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "collection" }
+                  "rel": {
+                    "const": "collection"
+                  }
                 }
               }
             }
@@ -206,16 +323,24 @@
         "item_assets"
       ],
       "properties": {
-        "stac_version": { "const": "1.0.0" },
+        "stac_version": {
+          "const": "1.0.0"
+        },
         "stac_extensions": {
           "const": [
             "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
-            "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+            "https://stac-extensions.github.io/projection/v2.0.0/schema.json"
           ]
         },
-        "type": { "const": "Collection" },
-        "id": { "const": "corine-land-cover-raster" },
-        "title": { "const": "CORINE Land Cover Raster" },
+        "type": {
+          "const": "Collection"
+        },
+        "id": {
+          "const": "corine-land-cover-raster"
+        },
+        "title": {
+          "const": "CORINE Land Cover Raster"
+        },
         "description": {
           "const": "The European Commission launched the CORINE (Coordination of Information on the Environment) program in an effort to develop a standardized methodology for producing continent-scale land cover, biotope, and air quality maps. The CORINE Land Cover (CLC) product offers a pan-European land cover and land use inventory with 44 thematic classes, ranging from broad forested areas to individual vineyards."
         },
@@ -229,13 +354,18 @@
             "open data"
           ]
         },
-        "license": { "const": "proprietary" },
+        "license": {
+          "const": "proprietary"
+        },
         "providers": {
           "const": [
             {
               "name": "Copernicus Land Monitoring Service",
               "description": "The Copernicus Land Monitoring Service provides geographical information on land cover and its changes, land use, ground motions, vegetation state, water cycle and Earth's surface energy variables to a broad range of users in Europe and across the World in the field of environmental terrestrial applications.",
-              "roles": ["licensor", "host"],
+              "roles": [
+                "licensor",
+                "host"
+              ],
               "url": "https://land.copernicus.eu/en"
             }
           ]
@@ -243,10 +373,22 @@
         "extent": {
           "const": {
             "spatial": {
-              "bbox": [[-61.906047, -21.482245, 55.935919, 71.409109]]
+              "bbox": [
+                [
+                  -61.906047,
+                  -21.482245,
+                  55.935919,
+                  71.409109
+                ]
+              ]
             },
             "temporal": {
-              "interval": [["1990-01-01T00:00:00.000Z", null]]
+              "interval": [
+                [
+                  "1990-01-01T00:00:00.000Z",
+                  null
+                ]
+              ]
             }
           }
         },
@@ -270,7 +412,9 @@
         },
         "summaries": {
           "type": "object",
-          "required": ["proj:epsg"],
+          "required": [
+            "proj:code"
+          ],
           "minProperties": 1,
           "maxProperties": 1
         },
@@ -281,7 +425,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "license" },
+                  "rel": {
+                    "const": "license"
+                  },
                   "href": {
                     "const": "https://land.copernicus.eu/en/data-policy"
                   }
@@ -292,7 +438,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "self" },
+                  "rel": {
+                    "const": "self"
+                  },
                   "href": {
                     "type": "string",
                     "pattern": ".json$"
@@ -304,7 +452,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "root" },
+                  "rel": {
+                    "const": "root"
+                  },
                   "href": {
                     "type": "string",
                     "pattern": ".json$"
@@ -316,7 +466,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "parent" },
+                  "rel": {
+                    "const": "parent"
+                  },
                   "href": {
                     "type": "string",
                     "pattern": ".json$"
@@ -328,7 +480,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "item" },
+                  "rel": {
+                    "const": "item"
+                  },
                   "href": {
                     "type": "string",
                     "pattern": ".json$"

--- a/schema/products/clc.json
+++ b/schema/products/clc.json
@@ -218,10 +218,7 @@
                 {
                   "name": "Copernicus Land Monitoring Service",
                   "description": "The Copernicus Land Monitoring Service provides geographical information on land cover and its changes, land use, ground motions, vegetation state, water cycle and Earth's surface energy variables to a broad range of users in Europe and across the World in the field of environmental terrestrial applications.",
-                  "roles": [
-                    "licensor",
-                    "host"
-                  ],
+                  "roles": ["licensor", "host"],
                   "url": "https://land.copernicus.eu"
                 }
               ]
@@ -362,10 +359,7 @@
             {
               "name": "Copernicus Land Monitoring Service",
               "description": "The Copernicus Land Monitoring Service provides geographical information on land cover and its changes, land use, ground motions, vegetation state, water cycle and Earth's surface energy variables to a broad range of users in Europe and across the World in the field of environmental terrestrial applications.",
-              "roles": [
-                "licensor",
-                "host"
-              ],
+              "roles": ["licensor", "host"],
               "url": "https://land.copernicus.eu/en"
             }
           ]
@@ -373,22 +367,10 @@
         "extent": {
           "const": {
             "spatial": {
-              "bbox": [
-                [
-                  -61.906047,
-                  -21.482245,
-                  55.935919,
-                  71.409109
-                ]
-              ]
+              "bbox": [[-61.906047, -21.482245, 55.935919, 71.409109]]
             },
             "temporal": {
-              "interval": [
-                [
-                  "1990-01-01T00:00:00.000Z",
-                  null
-                ]
-              ]
+              "interval": [["1990-01-01T00:00:00.000Z", null]]
             }
           }
         },
@@ -412,9 +394,7 @@
         },
         "summaries": {
           "type": "object",
-          "required": [
-            "proj:code"
-          ],
+          "required": ["proj:code"],
           "minProperties": 1,
           "maxProperties": 1
         },

--- a/schema/products/clcplus.json
+++ b/schema/products/clcplus.json
@@ -19,14 +19,20 @@
         "assets"
       ],
       "properties": {
-        "stac_version": { "const": "1.0.0" },
+        "stac_version": {
+          "const": "1.1.0"
+        },
         "stac_extensions": {
           "const": [
-            "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+            "https://stac-extensions.github.io/proj2.0.0/schema.json"
           ]
         },
-        "type": { "const": "Feature" },
-        "id": { "type": "string" },
+        "type": {
+          "const": "Feature"
+        },
+        "id": {
+          "type": "string"
+        },
         "bbox": {
           "type": "array",
           "minItems": 4,
@@ -34,50 +40,146 @@
           "oneOf": [
             {
               "items": [
-                { "type": "number", "minimum": -56.53, "maximum": -56.48 },
-                { "type": "number", "minimum": 24.26, "maximum": 24.31 },
-                { "type": "number", "minimum": 72.88, "maximum": 72.93 },
-                { "type": "number", "minimum": 72.61, "maximum": 72.66 }
+                {
+                  "type": "number",
+                  "minimum": -56.53,
+                  "maximum": -56.48
+                },
+                {
+                  "type": "number",
+                  "minimum": 24.26,
+                  "maximum": 24.31
+                },
+                {
+                  "type": "number",
+                  "minimum": 72.88,
+                  "maximum": 72.93
+                },
+                {
+                  "type": "number",
+                  "minimum": 72.61,
+                  "maximum": 72.66
+                }
               ]
             },
             {
               "items": [
-                { "type": "number", "minimum": -54.63, "maximum": -54.58 },
-                { "type": "number", "minimum": 2.08, "maximum": 2.13 },
-                { "type": "number", "minimum": -51.64, "maximum": -51.59 },
-                { "type": "number", "minimum": 5.74, "maximum": 5.79 }
+                {
+                  "type": "number",
+                  "minimum": -54.63,
+                  "maximum": -54.58
+                },
+                {
+                  "type": "number",
+                  "minimum": 2.08,
+                  "maximum": 2.13
+                },
+                {
+                  "type": "number",
+                  "minimum": -51.64,
+                  "maximum": -51.59
+                },
+                {
+                  "type": "number",
+                  "minimum": 5.74,
+                  "maximum": 5.79
+                }
               ]
             },
             {
               "items": [
-                { "type": "number", "minimum": -61.84, "maximum": -61.79 },
-                { "type": "number", "minimum": 15.81, "maximum": 15.86 },
-                { "type": "number", "minimum": -61.03, "maximum": -60.98 },
-                { "type": "number", "minimum": 16.49, "maximum": 16.54 }
+                {
+                  "type": "number",
+                  "minimum": -61.84,
+                  "maximum": -61.79
+                },
+                {
+                  "type": "number",
+                  "minimum": 15.81,
+                  "maximum": 15.86
+                },
+                {
+                  "type": "number",
+                  "minimum": -61.03,
+                  "maximum": -60.98
+                },
+                {
+                  "type": "number",
+                  "minimum": 16.49,
+                  "maximum": 16.54
+                }
               ]
             },
             {
               "items": [
-                { "type": "number", "minimum": -61.26, "maximum": -61.21 },
-                { "type": "number", "minimum": 14.36, "maximum": 14.41 },
-                { "type": "number", "minimum": -60.82, "maximum": -60.77 },
-                { "type": "number", "minimum": 14.85, "maximum": 14.9 }
+                {
+                  "type": "number",
+                  "minimum": -61.26,
+                  "maximum": -61.21
+                },
+                {
+                  "type": "number",
+                  "minimum": 14.36,
+                  "maximum": 14.41
+                },
+                {
+                  "type": "number",
+                  "minimum": -60.82,
+                  "maximum": -60.77
+                },
+                {
+                  "type": "number",
+                  "minimum": 14.85,
+                  "maximum": 14.9
+                }
               ]
             },
             {
               "items": [
-                { "type": "number", "minimum": 55.18, "maximum": 55.23 },
-                { "type": "number", "minimum": -21.41, "maximum": -21.36 },
-                { "type": "number", "minimum": 55.81, "maximum": 55.86 },
-                { "type": "number", "minimum": -20.9, "maximum": -20.85 }
+                {
+                  "type": "number",
+                  "minimum": 55.18,
+                  "maximum": 55.23
+                },
+                {
+                  "type": "number",
+                  "minimum": -21.41,
+                  "maximum": -21.36
+                },
+                {
+                  "type": "number",
+                  "minimum": 55.81,
+                  "maximum": 55.86
+                },
+                {
+                  "type": "number",
+                  "minimum": -20.9,
+                  "maximum": -20.85
+                }
               ]
             },
             {
               "items": [
-                { "type": "number", "minimum": 44.91, "maximum": 44.96 },
-                { "type": "number", "minimum": -13.1, "maximum": -13.05 },
-                { "type": "number", "minimum": 45.28, "maximum": 45.33 },
-                { "type": "number", "minimum": -12.6, "maximum": -12.55 }
+                {
+                  "type": "number",
+                  "minimum": 44.91,
+                  "maximum": 44.96
+                },
+                {
+                  "type": "number",
+                  "minimum": -13.1,
+                  "maximum": -13.05
+                },
+                {
+                  "type": "number",
+                  "minimum": 45.28,
+                  "maximum": 45.33
+                },
+                {
+                  "type": "number",
+                  "minimum": -12.6,
+                  "maximum": -12.55
+                }
               ]
             }
           ]
@@ -97,7 +199,9 @@
             "description": {
               "type": "string"
             },
-            "datetime": { "const": null },
+            "datetime": {
+              "const": null
+            },
             "start_datetime": {
               "type": "string",
               "pattern": "^20(17|20|22|24)-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\\.[0-9]{3})?Z$"
@@ -119,14 +223,19 @@
                 {
                   "name": "Copernicus Land Monitoring Service",
                   "description": "The Copernicus Land Monitoring Service provides geographical information on land cover and its changes, land use, ground motions, vegetation state, water cycle and Earth's surface energy variables to a broad range of users in Europe and across the World in the field of environmental terrestrial applications.",
-                  "roles": ["licensor", "host"],
+                  "roles": [
+                    "licensor",
+                    "host"
+                  ],
                   "url": "https://land.copernicus.eu"
                 }
               ]
             }
           }
         },
-        "collection": { "const": "corine-land-cover-plus-raster" },
+        "collection": {
+          "const": "corine-land-cover-plus-raster"
+        },
         "links": {
           "type": "array",
           "allOf": [
@@ -142,7 +251,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "self" }
+                  "rel": {
+                    "const": "self"
+                  }
                 }
               }
             },
@@ -150,7 +261,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "root" }
+                  "rel": {
+                    "const": "root"
+                  }
                 }
               }
             },
@@ -158,7 +271,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "parent" }
+                  "rel": {
+                    "const": "parent"
+                  }
                 }
               }
             },
@@ -166,7 +281,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "collection" }
+                  "rel": {
+                    "const": "collection"
+                  }
                 }
               }
             }
@@ -211,29 +328,47 @@
         "item_assets"
       ],
       "properties": {
-        "stac_version": { "const": "1.0.0" },
+        "stac_version": {
+          "const": "1.1.0"
+        },
         "stac_extensions": {
           "const": [
             "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
-            "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+            "https://stac-extensions.github.io/projection/v2.0.0/schema.json"
           ]
         },
-        "type": { "const": "Collection" },
-        "id": { "const": "corine-land-cover-plus-raster" },
-        "title": { "const": "CORINE Land Cover Plus Backbone" },
+        "type": {
+          "const": "Collection"
+        },
+        "id": {
+          "const": "corine-land-cover-plus-raster"
+        },
+        "title": {
+          "const": "CORINE Land Cover Plus Backbone"
+        },
         "description": {
           "const": "The CLC+ Backbone constitutes the first component of the CLMS’s new ‘CLC+ Product Suite’, which represents a true paradigm change in European land cover/land use (LC/LU) monitoring, building on the rich legacy of the European CORINE Land Cover (CLC) flagship product. The CLC+ Backbone is an object-oriented, large scale, wall-to-wall (EEA-38 + UK), high-resolution (HR) inventory of European LC in a vector format accompanied by a raster product layer, providing a consistent pan-European geometric backbone of Landscape Objects with limited, but robust thematic detail, on which many other applications can be built."
         },
         "keywords": {
-          "const": ["Copernicus", "Land Monitoring", "Land Cover", "CLC+"]
+          "const": [
+            "Copernicus",
+            "Land Monitoring",
+            "Land Cover",
+            "CLC+"
+          ]
         },
-        "license": { "const": "proprietary" },
+        "license": {
+          "const": "proprietary"
+        },
         "providers": {
           "const": [
             {
               "name": "Copernicus Land Monitoring Service",
               "description": "The Copernicus Land Monitoring Service provides geographical information on land cover and its changes, land use, ground motions, vegetation state, water cycle and Earth's surface energy variables to a broad range of users in Europe and across the World in the field of environmental terrestrial applications.",
-              "roles": ["licensor", "host"],
+              "roles": [
+                "licensor",
+                "host"
+              ],
               "url": "https://land.copernicus.eu/en"
             }
           ]
@@ -241,10 +376,22 @@
         "extent": {
           "const": {
             "spatial": {
-              "bbox": [[-56.5052, 24.2841, 72.9061, 72.6338]]
+              "bbox": [
+                [
+                  -56.5052,
+                  24.2841,
+                  72.9061,
+                  72.6338
+                ]
+              ]
             },
             "temporal": {
-              "interval": [["2018-01-01T00:00:00.000Z", null]]
+              "interval": [
+                [
+                  "2018-01-01T00:00:00.000Z",
+                  null
+                ]
+              ]
             }
           }
         },
@@ -272,11 +419,21 @@
         },
         "summaries": {
           "type": "object",
-          "required": ["proj:epsg"],
+          "required": [
+            "proj:code"
+          ],
           "minProperties": 1,
           "maxProperties": 1,
           "properties": {
-            "proj:epsg": { "const": [3035, 32620, 32622, 32738, 32740] }
+            "proj:code": {
+              "const": [
+                "EPSG:3035",
+                "EPSG:32620",
+                "EPSG:32622",
+                "EPSG:32738",
+                "EPSG:32740"
+              ]
+            }
           }
         },
         "links": {
@@ -286,7 +443,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "license" },
+                  "rel": {
+                    "const": "license"
+                  },
                   "href": {
                     "const": "https://land.copernicus.eu/en/data-policy"
                   }
@@ -297,7 +456,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "self" },
+                  "rel": {
+                    "const": "self"
+                  },
                   "href": {
                     "type": "string",
                     "pattern": ".json$"
@@ -309,7 +470,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "root" },
+                  "rel": {
+                    "const": "root"
+                  },
                   "href": {
                     "type": "string",
                     "pattern": ".json$"
@@ -321,7 +484,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "parent" },
+                  "rel": {
+                    "const": "parent"
+                  },
                   "href": {
                     "type": "string",
                     "pattern": ".json$"
@@ -333,7 +498,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "item" },
+                  "rel": {
+                    "const": "item"
+                  },
                   "href": {
                     "type": "string",
                     "pattern": ".json$"

--- a/schema/products/clcplus.json
+++ b/schema/products/clcplus.json
@@ -23,9 +23,7 @@
           "const": "1.1.0"
         },
         "stac_extensions": {
-          "const": [
-            "https://stac-extensions.github.io/proj2.0.0/schema.json"
-          ]
+          "const": ["https://stac-extensions.github.io/proj2.0.0/schema.json"]
         },
         "type": {
           "const": "Feature"
@@ -223,10 +221,7 @@
                 {
                   "name": "Copernicus Land Monitoring Service",
                   "description": "The Copernicus Land Monitoring Service provides geographical information on land cover and its changes, land use, ground motions, vegetation state, water cycle and Earth's surface energy variables to a broad range of users in Europe and across the World in the field of environmental terrestrial applications.",
-                  "roles": [
-                    "licensor",
-                    "host"
-                  ],
+                  "roles": ["licensor", "host"],
                   "url": "https://land.copernicus.eu"
                 }
               ]
@@ -350,12 +345,7 @@
           "const": "The CLC+ Backbone constitutes the first component of the CLMS’s new ‘CLC+ Product Suite’, which represents a true paradigm change in European land cover/land use (LC/LU) monitoring, building on the rich legacy of the European CORINE Land Cover (CLC) flagship product. The CLC+ Backbone is an object-oriented, large scale, wall-to-wall (EEA-38 + UK), high-resolution (HR) inventory of European LC in a vector format accompanied by a raster product layer, providing a consistent pan-European geometric backbone of Landscape Objects with limited, but robust thematic detail, on which many other applications can be built."
         },
         "keywords": {
-          "const": [
-            "Copernicus",
-            "Land Monitoring",
-            "Land Cover",
-            "CLC+"
-          ]
+          "const": ["Copernicus", "Land Monitoring", "Land Cover", "CLC+"]
         },
         "license": {
           "const": "proprietary"
@@ -365,10 +355,7 @@
             {
               "name": "Copernicus Land Monitoring Service",
               "description": "The Copernicus Land Monitoring Service provides geographical information on land cover and its changes, land use, ground motions, vegetation state, water cycle and Earth's surface energy variables to a broad range of users in Europe and across the World in the field of environmental terrestrial applications.",
-              "roles": [
-                "licensor",
-                "host"
-              ],
+              "roles": ["licensor", "host"],
               "url": "https://land.copernicus.eu/en"
             }
           ]
@@ -376,22 +363,10 @@
         "extent": {
           "const": {
             "spatial": {
-              "bbox": [
-                [
-                  -56.5052,
-                  24.2841,
-                  72.9061,
-                  72.6338
-                ]
-              ]
+              "bbox": [[-56.5052, 24.2841, 72.9061, 72.6338]]
             },
             "temporal": {
-              "interval": [
-                [
-                  "2018-01-01T00:00:00.000Z",
-                  null
-                ]
-              ]
+              "interval": [["2018-01-01T00:00:00.000Z", null]]
             }
           }
         },
@@ -419,9 +394,7 @@
         },
         "summaries": {
           "type": "object",
-          "required": [
-            "proj:code"
-          ],
+          "required": ["proj:code"],
           "minProperties": 1,
           "maxProperties": 1,
           "properties": {

--- a/schema/products/eu-hydro.json
+++ b/schema/products/eu-hydro.json
@@ -71,59 +71,37 @@
             {
               "name": "Copernicus Land Monitoring Service",
               "description": "The Copernicus Land Monitoring Service provides geographical information on land cover and its changes, land use, ground motions, vegetation state, water cycle and Earth's surface energy variables to a broad range of users in Europe and across the World in the field of environmental terrestrial applications.",
-              "roles": [
-                "licensor",
-                "host"
-              ],
+              "roles": ["licensor", "host"],
               "url": "https://land.copernicus.eu"
             }
           ]
         },
         "extent": {
           "type": "object",
-          "required": [
-            "spatial",
-            "temporal"
-          ],
+          "required": ["spatial", "temporal"],
           "minProperties": 2,
           "maxProperties": 2,
           "properties": {
             "spatial": {
               "const": {
-                "bbox": [
-                  [
-                    -61.906047,
-                    -21.482245,
-                    55.935919,
-                    71.409109
-                  ]
-                ]
+                "bbox": [[-61.906047, -21.482245, 55.935919, 71.409109]]
               }
             },
             "temporal": {
               "const": {
-                "interval": [
-                  [
-                    "2006-01-01T00:00:00Z",
-                    "2012-12-31T00:00:00Z"
-                  ]
-                ]
+                "interval": [["2006-01-01T00:00:00Z", "2012-12-31T00:00:00Z"]]
               }
             }
           }
         },
         "summaries": {
           "type": "object",
-          "required": [
-            "proj:code"
-          ],
+          "required": ["proj:code"],
           "minProperties": 1,
           "maxProperties": 1,
           "properties": {
             "proj:code": {
-              "const": [
-                "EPSG:3035"
-              ]
+              "const": ["EPSG:3035"]
             }
           }
         },

--- a/schema/products/eu-hydro.json
+++ b/schema/products/eu-hydro.json
@@ -23,15 +23,23 @@
         "assets"
       ],
       "properties": {
-        "stac_version": { "const": "1.0.0" },
+        "stac_version": {
+          "const": "1.1.0"
+        },
         "stac_extensions": {
           "const": [
-            "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+            "https://stac-extensions.github.io/projection/v2.0.0/schema.json"
           ]
         },
-        "type": { "const": "Collection" },
-        "id": { "const": "eu-hydro" },
-        "title": { "const": "EU-Hydro River Network Database" },
+        "type": {
+          "const": "Collection"
+        },
+        "id": {
+          "const": "eu-hydro"
+        },
+        "title": {
+          "const": "EU-Hydro River Network Database"
+        },
         "description": {
           "const": "EU-Hydro is a dataset for all EEA38 countries and the United Kingdom providing photo-interpreted river network, consistent of surface interpretation of water bodies (lakes and wide rivers), and a drainage model (also called Drainage Network), derived from EU-DEM, with catchments and drainage lines and nodes."
         },
@@ -55,43 +63,67 @@
             "Water body"
           ]
         },
-        "license": { "const": "proprietary" },
+        "license": {
+          "const": "proprietary"
+        },
         "providers": {
           "const": [
             {
               "name": "Copernicus Land Monitoring Service",
               "description": "The Copernicus Land Monitoring Service provides geographical information on land cover and its changes, land use, ground motions, vegetation state, water cycle and Earth's surface energy variables to a broad range of users in Europe and across the World in the field of environmental terrestrial applications.",
-              "roles": ["licensor", "host"],
+              "roles": [
+                "licensor",
+                "host"
+              ],
               "url": "https://land.copernicus.eu"
             }
           ]
         },
         "extent": {
           "type": "object",
-          "required": ["spatial", "temporal"],
+          "required": [
+            "spatial",
+            "temporal"
+          ],
           "minProperties": 2,
           "maxProperties": 2,
           "properties": {
             "spatial": {
               "const": {
-                "bbox": [[-61.906047, -21.482245, 55.935919, 71.409109]]
+                "bbox": [
+                  [
+                    -61.906047,
+                    -21.482245,
+                    55.935919,
+                    71.409109
+                  ]
+                ]
               }
             },
             "temporal": {
               "const": {
-                "interval": [["2006-01-01T00:00:00Z", "2012-12-31T00:00:00Z"]]
+                "interval": [
+                  [
+                    "2006-01-01T00:00:00Z",
+                    "2012-12-31T00:00:00Z"
+                  ]
+                ]
               }
             }
           }
         },
         "summaries": {
           "type": "object",
-          "required": ["proj:epsg"],
+          "required": [
+            "proj:code"
+          ],
           "minProperties": 1,
           "maxProperties": 1,
           "properties": {
-            "proj:epsg": {
-              "const": [3035]
+            "proj:code": {
+              "const": [
+                "EPSG:3035"
+              ]
             }
           }
         },
@@ -102,7 +134,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "license" },
+                  "rel": {
+                    "const": "license"
+                  },
                   "href": {
                     "const": "https://land.copernicus.eu/en/data-policy"
                   }
@@ -113,7 +147,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "self" },
+                  "rel": {
+                    "const": "self"
+                  },
                   "href": {
                     "type": "string",
                     "pattern": ".json$"
@@ -125,7 +161,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "root" },
+                  "rel": {
+                    "const": "root"
+                  },
                   "href": {
                     "type": "string",
                     "pattern": ".json$"
@@ -137,7 +175,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "parent" },
+                  "rel": {
+                    "const": "parent"
+                  },
                   "href": {
                     "type": "string",
                     "pattern": ".json$"

--- a/schema/products/ibu10m.json
+++ b/schema/products/ibu10m.json
@@ -20,11 +20,11 @@
       ],
       "properties": {
         "stac_version": {
-          "const": "1.0.0"
+          "const": "1.1.0"
         },
         "stac_extensions": {
           "const": [
-            "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+            "https://stac-extensions.github.io/projection/v2.0.0/schema.json"
           ]
         },
         "type": {
@@ -55,7 +55,11 @@
                   "minimum": 18.140136,
                   "maximum": 19.329582
                 },
-                { "type": "number", "minimum": 41.672629, "maximum": 42.463926 }
+                {
+                  "type": "number",
+                  "minimum": 41.672629,
+                  "maximum": 42.463926
+                }
               ]
             }
           ]
@@ -69,7 +73,7 @@
             "end_datetime",
             "created",
             "providers",
-            "proj:epsg",
+            "proj:code",
             "proj:bbox",
             "proj:shape"
           ],
@@ -79,8 +83,22 @@
                 {
                   "name": "Copernicus Land Monitoring Service",
                   "description": "The Copernicus Land Monitoring Service provides geographical information on land cover and its changes, land use, ground motions, vegetation state, water cycle and Earth's surface energy variables to a broad range of users in Europe and across the World in the field of environmental terrestrial applications.",
-                  "roles": ["licensor", "host"],
+                  "roles": [
+                    "licensor",
+                    "host"
+                  ],
                   "url": "https://land.copernicus.eu"
+                }
+              ]
+            },
+            "proj:code": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "pattern": "^EPSG:\\d+$"
+                },
+                {
+                  "type": "integer"
                 }
               ]
             }
@@ -187,12 +205,12 @@
       ],
       "properties": {
         "stac_version": {
-          "const": "1.0.0"
+          "const": "1.1.0"
         },
         "stac_extensions": {
           "const": [
             "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
-            "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+            "https://stac-extensions.github.io/projection/v2.0.0/schema.json"
           ]
         },
         "type": {
@@ -226,7 +244,10 @@
             {
               "name": "Copernicus Land Monitoring Service",
               "description": "The Copernicus Land Monitoring Service provides geographical information on land cover and its changes, land use, ground motions, vegetation state, water cycle and Earth's surface energy variables to a broad range of users in Europe and across the World in the field of environmental terrestrial applications.",
-              "roles": ["licensor", "host"],
+              "roles": [
+                "licensor",
+                "host"
+              ],
               "url": "https://land.copernicus.eu/en"
             }
           ]
@@ -234,10 +255,22 @@
         "extent": {
           "const": {
             "spatial": {
-              "bbox": [[-31.285, 27.642, 44.807, 71.165]]
+              "bbox": [
+                [
+                  -31.285,
+                  27.642,
+                  44.807,
+                  71.165
+                ]
+              ]
             },
             "temporal": {
-              "interval": [["2018-01-01T00:00:00.000Z", null]]
+              "interval": [
+                [
+                  "2018-01-01T00:00:00.000Z",
+                  null
+                ]
+              ]
             }
           }
         },
@@ -260,9 +293,24 @@
         },
         "summaries": {
           "type": "object",
-          "required": ["proj:epsg"],
+          "required": [
+            "proj:code"
+          ],
           "minProperties": 1,
-          "maxProperties": 1
+          "maxProperties": 1,
+          "properties": {
+            "proj:code": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "pattern": "^EPSG:\\d+$"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            }
+          }
         },
         "links": {
           "type": "array",

--- a/schema/products/ibu10m.json
+++ b/schema/products/ibu10m.json
@@ -83,10 +83,7 @@
                 {
                   "name": "Copernicus Land Monitoring Service",
                   "description": "The Copernicus Land Monitoring Service provides geographical information on land cover and its changes, land use, ground motions, vegetation state, water cycle and Earth's surface energy variables to a broad range of users in Europe and across the World in the field of environmental terrestrial applications.",
-                  "roles": [
-                    "licensor",
-                    "host"
-                  ],
+                  "roles": ["licensor", "host"],
                   "url": "https://land.copernicus.eu"
                 }
               ]
@@ -244,10 +241,7 @@
             {
               "name": "Copernicus Land Monitoring Service",
               "description": "The Copernicus Land Monitoring Service provides geographical information on land cover and its changes, land use, ground motions, vegetation state, water cycle and Earth's surface energy variables to a broad range of users in Europe and across the World in the field of environmental terrestrial applications.",
-              "roles": [
-                "licensor",
-                "host"
-              ],
+              "roles": ["licensor", "host"],
               "url": "https://land.copernicus.eu/en"
             }
           ]
@@ -255,22 +249,10 @@
         "extent": {
           "const": {
             "spatial": {
-              "bbox": [
-                [
-                  -31.285,
-                  27.642,
-                  44.807,
-                  71.165
-                ]
-              ]
+              "bbox": [[-31.285, 27.642, 44.807, 71.165]]
             },
             "temporal": {
-              "interval": [
-                [
-                  "2018-01-01T00:00:00.000Z",
-                  null
-                ]
-              ]
+              "interval": [["2018-01-01T00:00:00.000Z", null]]
             }
           }
         },
@@ -293,9 +275,7 @@
         },
         "summaries": {
           "type": "object",
-          "required": [
-            "proj:code"
-          ],
+          "required": ["proj:code"],
           "minProperties": 1,
           "maxProperties": 1,
           "properties": {

--- a/schema/products/n2k.json
+++ b/schema/products/n2k.json
@@ -63,20 +63,14 @@
             {
               "name": "Copernicus Land Monitoring Service",
               "description": "The Copernicus Land Monitoring Service provides geographical information on land cover and its changes, land use, ground motions, vegetation state, water cycle and Earth's surface energy variables to a broad range of users in Europe and across the World in the field of environmental terrestrial applications.",
-              "roles": [
-                "licensor",
-                "host"
-              ],
+              "roles": ["licensor", "host"],
               "url": "https://land.copernicus.eu"
             }
           ]
         },
         "extent": {
           "type": "object",
-          "required": [
-            "spatial",
-            "temporal"
-          ],
+          "required": ["spatial", "temporal"],
           "minProperties": 2,
           "maxProperties": 2,
           "properties": {
@@ -84,54 +78,31 @@
               "oneOf": [
                 {
                   "const": {
-                    "bbox": [
-                      [
-                        -16.82,
-                        27.87,
-                        33.17,
-                        66.79
-                      ]
-                    ]
+                    "bbox": [[-16.82, 27.87, 33.17, 66.79]]
                   }
                 },
                 {
                   "const": {
-                    "bbox": [
-                      [
-                        -16.81,
-                        27.87,
-                        33.17,
-                        66.79
-                      ]
-                    ]
+                    "bbox": [[-16.81, 27.87, 33.17, 66.79]]
                   }
                 }
               ]
             },
             "temporal": {
               "const": {
-                "interval": [
-                  [
-                    "2006-01-01T00:00:00Z",
-                    null
-                  ]
-                ]
+                "interval": [["2006-01-01T00:00:00Z", null]]
               }
             }
           }
         },
         "summaries": {
           "type": "object",
-          "required": [
-            "proj:code"
-          ],
+          "required": ["proj:code"],
           "minProperties": 1,
           "maxProperties": 1,
           "properties": {
             "proj:code": {
-              "const": [
-                "EPSG:3035"
-              ]
+              "const": ["EPSG:3035"]
             }
           }
         },

--- a/schema/products/n2k.json
+++ b/schema/products/n2k.json
@@ -23,15 +23,23 @@
         "assets"
       ],
       "properties": {
-        "stac_version": { "const": "1.0.0" },
+        "stac_version": {
+          "const": "1.1.0"
+        },
         "stac_extensions": {
           "const": [
-            "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+            "https://stac-extensions.github.io/projection/v2.0.0/schema.json"
           ]
         },
-        "type": { "const": "Collection" },
-        "id": { "const": "natura2000" },
-        "title": { "const": "Natura 2000 Land Cover/Land Use Status" },
+        "type": {
+          "const": "Collection"
+        },
+        "id": {
+          "const": "natura2000"
+        },
+        "title": {
+          "const": "Natura 2000 Land Cover/Land Use Status"
+        },
         "description": {
           "const": "The Copernicus Land Cover/Land Use (LC/LU) status map as part of the Copernicus Land Monitoring Service (CLMS) Local Component, tailored to the needs of biodiversity monitoring in selected Natura2000 sites (4790 sites of natural and semi-natural grassland formations listed in Annex I of the Habitats Directive) including a 2km buffer zone surrounding the sites and covering an area of 631.820 km² across Europe. LC/LU is extracted from VHR satellite data and other available data."
         },
@@ -47,42 +55,83 @@
             "Landscape"
           ]
         },
-        "license": { "const": "proprietary" },
+        "license": {
+          "const": "proprietary"
+        },
         "providers": {
           "const": [
             {
               "name": "Copernicus Land Monitoring Service",
               "description": "The Copernicus Land Monitoring Service provides geographical information on land cover and its changes, land use, ground motions, vegetation state, water cycle and Earth's surface energy variables to a broad range of users in Europe and across the World in the field of environmental terrestrial applications.",
-              "roles": ["licensor", "host"],
+              "roles": [
+                "licensor",
+                "host"
+              ],
               "url": "https://land.copernicus.eu"
             }
           ]
         },
         "extent": {
           "type": "object",
-          "required": ["spatial", "temporal"],
+          "required": [
+            "spatial",
+            "temporal"
+          ],
           "minProperties": 2,
           "maxProperties": 2,
           "properties": {
             "spatial": {
               "oneOf": [
-                { "const": { "bbox": [[-16.82, 27.87, 33.17, 66.79]] } },
-                { "const": { "bbox": [[-16.81, 27.87, 33.17, 66.79]] } }
+                {
+                  "const": {
+                    "bbox": [
+                      [
+                        -16.82,
+                        27.87,
+                        33.17,
+                        66.79
+                      ]
+                    ]
+                  }
+                },
+                {
+                  "const": {
+                    "bbox": [
+                      [
+                        -16.81,
+                        27.87,
+                        33.17,
+                        66.79
+                      ]
+                    ]
+                  }
+                }
               ]
             },
             "temporal": {
-              "const": { "interval": [["2006-01-01T00:00:00Z", null]] }
+              "const": {
+                "interval": [
+                  [
+                    "2006-01-01T00:00:00Z",
+                    null
+                  ]
+                ]
+              }
             }
           }
         },
         "summaries": {
           "type": "object",
-          "required": ["proj:epsg"],
+          "required": [
+            "proj:code"
+          ],
           "minProperties": 1,
           "maxProperties": 1,
           "properties": {
-            "proj:epsg": {
-              "const": [3035]
+            "proj:code": {
+              "const": [
+                "EPSG:3035"
+              ]
             }
           }
         },
@@ -93,7 +142,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "license" },
+                  "rel": {
+                    "const": "license"
+                  },
                   "href": {
                     "const": "https://land.copernicus.eu/en/data-policy"
                   }
@@ -104,7 +155,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "self" },
+                  "rel": {
+                    "const": "self"
+                  },
                   "href": {
                     "type": "string",
                     "pattern": ".json$"
@@ -116,7 +169,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "root" },
+                  "rel": {
+                    "const": "root"
+                  },
                   "href": {
                     "type": "string",
                     "pattern": ".json$"
@@ -128,7 +183,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "parent" },
+                  "rel": {
+                    "const": "parent"
+                  },
                   "href": {
                     "type": "string",
                     "pattern": ".json$"

--- a/schema/products/rlie-s2.json
+++ b/schema/products/rlie-s2.json
@@ -89,10 +89,7 @@
                 {
                   "name": "Copernicus Land Monitoring Service",
                   "description": "The Copernicus Land Monitoring Service provides geographical information on land cover and its changes, land use, ground motions, vegetation state, water cycle and Earth's surface energy variables to a broad range of users in Europe and across the World in the field of environmental terrestrial applications.",
-                  "roles": [
-                    "licensor",
-                    "host"
-                  ],
+                  "roles": ["licensor", "host"],
                   "url": "https://land.copernicus.eu"
                 }
               ]
@@ -108,10 +105,7 @@
               }
             },
             "proj:shape": {
-              "const": [
-                5490,
-                5490
-              ]
+              "const": [5490, 5490]
             }
           }
         },
@@ -240,10 +234,7 @@
             {
               "name": "Copernicus Land Monitoring Service",
               "description": "The Copernicus Land Monitoring Service provides geographical information on land cover and its changes, land use, ground motions, vegetation state, water cycle and Earth's surface energy variables to a broad range of users in Europe and across the World in the field of environmental terrestrial applications.",
-              "roles": [
-                "licensor",
-                "host"
-              ],
+              "roles": ["licensor", "host"],
               "url": "https://land.copernicus.eu/en"
             }
           ]
@@ -251,30 +242,16 @@
         "extent": {
           "const": {
             "spatial": {
-              "bbox": [
-                [
-                  -26,
-                  34,
-                  44,
-                  66
-                ]
-              ]
+              "bbox": [[-26, 34, 44, 66]]
             },
             "temporal": {
-              "interval": [
-                [
-                  "2016-09-01T00:00:00.000Z",
-                  null
-                ]
-              ]
+              "interval": [["2016-09-01T00:00:00.000Z", null]]
             }
           }
         },
         "summaries": {
           "type": "object",
-          "required": [
-            "proj:code"
-          ],
+          "required": ["proj:code"],
           "minProperties": 1,
           "maxProperties": 1,
           "properties": {
@@ -374,12 +351,7 @@
         },
         "item_assets": {
           "type": "object",
-          "required": [
-            "RLIE",
-            "QC",
-            "QCFLAGS",
-            "MTD"
-          ],
+          "required": ["RLIE", "QC", "QCFLAGS", "MTD"],
           "maxProperties": 4,
           "minProperties": 4
         }

--- a/schema/products/rlie-s2.json
+++ b/schema/products/rlie-s2.json
@@ -19,13 +19,17 @@
         "assets"
       ],
       "properties": {
-        "stac_version": { "const": "1.0.0" },
+        "stac_version": {
+          "const": "1.1.0"
+        },
         "stac_extensions": {
           "const": [
-            "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+            "https://stac-extensions.github.io/projection/v2.0.0/schema.json"
           ]
         },
-        "type": { "const": "Feature" },
+        "type": {
+          "const": "Feature"
+        },
         "id": {
           "type": "string",
           "pattern": "^RLIE_(201[6-9]|20[2-9][0-9])(0[1-9]|1[0-2])(0[1-9]|[1-2][0-9]|3[0-1])T([0-1][0-9]|2[0-3])([0-5][0-9]){2}_S2[A|B]_T(0[1-9]|[1-5][0-9]|60)([A-X]{3})_V"
@@ -35,10 +39,26 @@
           "minItems": 4,
           "maxItems": 4,
           "items": [
-            { "type": "number", "minimum": -25, "maximum": 45 },
-            { "type": "number", "minimum": 26, "maximum": 72 },
-            { "type": "number", "minimum": -25, "maximum": 45 },
-            { "type": "number", "minimum": 26, "maximum": 72 }
+            {
+              "type": "number",
+              "minimum": -25,
+              "maximum": 45
+            },
+            {
+              "type": "number",
+              "minimum": 26,
+              "maximum": 72
+            },
+            {
+              "type": "number",
+              "minimum": -25,
+              "maximum": 45
+            },
+            {
+              "type": "number",
+              "minimum": 26,
+              "maximum": 72
+            }
           ]
         },
         "properties": {
@@ -48,12 +68,14 @@
             "datetime",
             "created",
             "providers",
-            "proj:epsg",
+            "proj:code",
             "proj:bbox",
             "proj:shape"
           ],
           "properties": {
-            "description": { "type": "string" },
+            "description": {
+              "type": "string"
+            },
             "datetime": {
               "type": "string",
               "pattern": "(201[6-9]|20[2-9][0-9])-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([0-1][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])(\\.[0-9]{3})?Z"
@@ -67,15 +89,17 @@
                 {
                   "name": "Copernicus Land Monitoring Service",
                   "description": "The Copernicus Land Monitoring Service provides geographical information on land cover and its changes, land use, ground motions, vegetation state, water cycle and Earth's surface energy variables to a broad range of users in Europe and across the World in the field of environmental terrestrial applications.",
-                  "roles": ["licensor", "host"],
+                  "roles": [
+                    "licensor",
+                    "host"
+                  ],
                   "url": "https://land.copernicus.eu"
                 }
               ]
             },
-            "proj:epsg": {
-              "type": "integer",
-              "minimum": 32625,
-              "maximum": 32638
+            "proj:code": {
+              "type": "string",
+              "pattern": "^EPSG:326(2[5-9]|3[0-8])$"
             },
             "proj:bbox": {
               "type": "array",
@@ -84,11 +108,16 @@
               }
             },
             "proj:shape": {
-              "const": [5490, 5490]
+              "const": [
+                5490,
+                5490
+              ]
             }
           }
         },
-        "collection": { "const": "river-and-lake-ice-extent-s2" },
+        "collection": {
+          "const": "river-and-lake-ice-extent-s2"
+        },
         "links": {
           "type": "array",
           "allOf": [
@@ -104,7 +133,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "self" }
+                  "rel": {
+                    "const": "self"
+                  }
                 }
               }
             },
@@ -112,7 +143,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "root" }
+                  "rel": {
+                    "const": "root"
+                  }
                 }
               }
             },
@@ -120,7 +153,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "parent" }
+                  "rel": {
+                    "const": "parent"
+                  }
                 }
               }
             },
@@ -128,7 +163,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "collection" }
+                  "rel": {
+                    "const": "collection"
+                  }
                 }
               }
             }
@@ -163,15 +200,21 @@
         "item_assets"
       ],
       "properties": {
-        "stac_version": { "const": "1.0.0" },
+        "stac_version": {
+          "const": "1.1.0"
+        },
         "stac_extensions": {
           "const": [
             "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
-            "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+            "https://stac-extensions.github.io/projection/v2.0.0/schema.json"
           ]
         },
-        "type": { "const": "Collection" },
-        "id": { "const": "river-and-lake-ice-extent-s2" },
+        "type": {
+          "const": "Collection"
+        },
+        "id": {
+          "const": "river-and-lake-ice-extent-s2"
+        },
         "title": {
           "const": "Rive and Lake Ice Extent - Sentinel-2"
         },
@@ -189,13 +232,18 @@
             "lake"
           ]
         },
-        "license": { "const": "proprietary" },
+        "license": {
+          "const": "proprietary"
+        },
         "providers": {
           "const": [
             {
               "name": "Copernicus Land Monitoring Service",
               "description": "The Copernicus Land Monitoring Service provides geographical information on land cover and its changes, land use, ground motions, vegetation state, water cycle and Earth's surface energy variables to a broad range of users in Europe and across the World in the field of environmental terrestrial applications.",
-              "roles": ["licensor", "host"],
+              "roles": [
+                "licensor",
+                "host"
+              ],
               "url": "https://land.copernicus.eu/en"
             }
           ]
@@ -203,23 +251,49 @@
         "extent": {
           "const": {
             "spatial": {
-              "bbox": [[-26, 34, 44, 66]]
+              "bbox": [
+                [
+                  -26,
+                  34,
+                  44,
+                  66
+                ]
+              ]
             },
             "temporal": {
-              "interval": [["2016-09-01T00:00:00.000Z", null]]
+              "interval": [
+                [
+                  "2016-09-01T00:00:00.000Z",
+                  null
+                ]
+              ]
             }
           }
         },
         "summaries": {
           "type": "object",
-          "required": ["proj:epsg"],
+          "required": [
+            "proj:code"
+          ],
           "minProperties": 1,
           "maxProperties": 1,
           "properties": {
-            "proj:epsg": {
+            "proj:code": {
               "const": [
-                32625, 32626, 32627, 32628, 32629, 32630, 32631, 32632, 32633,
-                32634, 32635, 32636, 32637, 32638
+                "EPSG:32625",
+                "EPSG:32626",
+                "EPSG:32627",
+                "EPSG:32628",
+                "EPSG:32629",
+                "EPSG:32630",
+                "EPSG:32631",
+                "EPSG:32632",
+                "EPSG:32633",
+                "EPSG:32634",
+                "EPSG:32635",
+                "EPSG:32636",
+                "EPSG:32637",
+                "EPSG:32638"
               ]
             }
           }
@@ -231,7 +305,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "license" },
+                  "rel": {
+                    "const": "license"
+                  },
                   "href": {
                     "const": "https://land.copernicus.eu/en/data-policy"
                   }
@@ -242,7 +318,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "self" },
+                  "rel": {
+                    "const": "self"
+                  },
                   "href": {
                     "type": "string",
                     "pattern": ".json$"
@@ -254,7 +332,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "root" },
+                  "rel": {
+                    "const": "root"
+                  },
                   "href": {
                     "type": "string",
                     "pattern": ".json$"
@@ -266,7 +346,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "parent" },
+                  "rel": {
+                    "const": "parent"
+                  },
                   "href": {
                     "type": "string",
                     "pattern": ".json$"
@@ -278,7 +360,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "item" },
+                  "rel": {
+                    "const": "item"
+                  },
                   "href": {
                     "type": "string",
                     "pattern": ".json$"
@@ -290,7 +374,12 @@
         },
         "item_assets": {
           "type": "object",
-          "required": ["RLIE", "QC", "QCFLAGS", "MTD"],
+          "required": [
+            "RLIE",
+            "QC",
+            "QCFLAGS",
+            "MTD"
+          ],
           "maxProperties": 4,
           "minProperties": 4
         }

--- a/schema/products/uabh.json
+++ b/schema/products/uabh.json
@@ -98,10 +98,7 @@
                 {
                   "name": "Copernicus Land Monitoring Service",
                   "description": "The Copernicus Land Monitoring Service provides geographical information on land cover and its changes, land use, ground motions, vegetation state, water cycle and Earth's surface energy variables to a broad range of users in Europe and across the World in the field of environmental terrestrial applications.",
-                  "roles": [
-                    "licensor",
-                    "host"
-                  ],
+                  "roles": ["licensor", "host"],
                   "url": "https://land.copernicus.eu"
                 }
               ]
@@ -228,11 +225,7 @@
           "const": "Urban Atlas building height over capital cities."
         },
         "keywords": {
-          "const": [
-            "Buildings",
-            "Building height",
-            "Elevation"
-          ]
+          "const": ["Buildings", "Building height", "Elevation"]
         },
         "license": {
           "const": "proprietary"
@@ -242,10 +235,7 @@
             {
               "name": "Copernicus Land Monitoring Service",
               "description": "The Copernicus Land Monitoring Service provides geographical information on land cover and its changes, land use, ground motions, vegetation state, water cycle and Earth's surface energy variables to a broad range of users in Europe and across the World in the field of environmental terrestrial applications.",
-              "roles": [
-                "licensor",
-                "host"
-              ],
+              "roles": ["licensor", "host"],
               "url": "https://land.copernicus.eu"
             }
           ]
@@ -253,37 +243,21 @@
         "extent": {
           "const": {
             "spatial": {
-              "bbox": [
-                [
-                  -22.13,
-                  35.07,
-                  33.48,
-                  64.38
-                ]
-              ]
+              "bbox": [[-22.13, 35.07, 33.48, 64.38]]
             },
             "temporal": {
-              "interval": [
-                [
-                  "2012-01-01T00:00:00Z",
-                  null
-                ]
-              ]
+              "interval": [["2012-01-01T00:00:00Z", null]]
             }
           }
         },
         "summaries": {
           "type": "object",
-          "required": [
-            "proj:code"
-          ],
+          "required": ["proj:code"],
           "minProperties": 1,
           "maxProperties": 1,
           "properties": {
             "proj:code": {
-              "const": [
-                "EPSG:3035"
-              ]
+              "const": ["EPSG:3035"]
             }
           }
         },

--- a/schema/products/uabh.json
+++ b/schema/products/uabh.json
@@ -19,13 +19,17 @@
         "assets"
       ],
       "properties": {
-        "stac_version": { "const": "1.0.0" },
+        "stac_version": {
+          "const": "1.1.0"
+        },
         "stac_extensions": {
           "const": [
-            "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+            "https://stac-extensions.github.io/projection/v2.0.0/schema.json"
           ]
         },
-        "type": { "const": "Feature" },
+        "type": {
+          "const": "Feature"
+        },
         "id": {
           "type": "string",
           "pattern": "^(A[LT]|B[AEG]|C[HYZ]|D[EK]|E[ELS]|F[IR]|H[RU]|I[EST]|L[TUV]|M[EKT]|N[LO]|P[LT]|R[OS]|S[EIK]|TR|UK|XK)[0-9]{3}"
@@ -35,10 +39,26 @@
           "minItems": 4,
           "maxItems": 4,
           "items": [
-            { "type": "number", "minimum": -22.13, "maximum": 33.48 },
-            { "type": "number", "minimum": 35.07, "maximum": 64.38 },
-            { "type": "number", "minimum": -22.13, "maximum": 33.48 },
-            { "type": "number", "minimum": 35.07, "maximum": 64.38 }
+            {
+              "type": "number",
+              "minimum": -22.13,
+              "maximum": 33.48
+            },
+            {
+              "type": "number",
+              "minimum": 35.07,
+              "maximum": 64.38
+            },
+            {
+              "type": "number",
+              "minimum": -22.13,
+              "maximum": 33.48
+            },
+            {
+              "type": "number",
+              "minimum": 35.07,
+              "maximum": 64.38
+            }
           ]
         },
         "properties": {
@@ -50,13 +70,17 @@
             "end_datetime",
             "created",
             "providers",
-            "proj:epsg",
+            "proj:code",
             "proj:bbox",
             "proj:shape"
           ],
           "properties": {
-            "description": { "type": "string" },
-            "datetime": { "const": null },
+            "description": {
+              "type": "string"
+            },
+            "datetime": {
+              "const": null
+            },
             "start_datetime": {
               "type": "string",
               "pattern": "20(1[0-4])-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T(0[0-9]|1[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])(\\.[0-9]{3})?Z"
@@ -74,12 +98,17 @@
                 {
                   "name": "Copernicus Land Monitoring Service",
                   "description": "The Copernicus Land Monitoring Service provides geographical information on land cover and its changes, land use, ground motions, vegetation state, water cycle and Earth's surface energy variables to a broad range of users in Europe and across the World in the field of environmental terrestrial applications.",
-                  "roles": ["licensor", "host"],
+                  "roles": [
+                    "licensor",
+                    "host"
+                  ],
                   "url": "https://land.copernicus.eu"
                 }
               ]
             },
-            "proj:epsg": { "const": 3035 },
+            "proj:code": {
+              "const": "EPSG:3035"
+            },
             "proj:bbox": {
               "type": "array",
               "items": {
@@ -94,7 +123,9 @@
             }
           }
         },
-        "collection": { "const": "urban-atlas-building-height" },
+        "collection": {
+          "const": "urban-atlas-building-height"
+        },
         "links": {
           "type": "array",
           "allOf": [
@@ -110,7 +141,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "self" }
+                  "rel": {
+                    "const": "self"
+                  }
                 }
               }
             },
@@ -118,7 +151,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "root" }
+                  "rel": {
+                    "const": "root"
+                  }
                 }
               }
             },
@@ -126,7 +161,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "parent" }
+                  "rel": {
+                    "const": "parent"
+                  }
                 }
               }
             },
@@ -134,7 +171,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "collection" }
+                  "rel": {
+                    "const": "collection"
+                  }
                 }
               }
             }
@@ -167,15 +206,21 @@
         "item_assets"
       ],
       "properties": {
-        "stac_version": { "const": "1.0.0" },
+        "stac_version": {
+          "const": "1.1.0"
+        },
         "stac_extensions": {
           "const": [
-            "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
+            "https://stac-extensions.github.io/projection/v2.0.0/schema.json",
             "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
           ]
         },
-        "type": { "const": "Collection" },
-        "id": { "const": "urban-atlas-building-height" },
+        "type": {
+          "const": "Collection"
+        },
+        "id": {
+          "const": "urban-atlas-building-height"
+        },
         "title": {
           "const": "Urban Atlas Building Height 10m"
         },
@@ -183,15 +228,24 @@
           "const": "Urban Atlas building height over capital cities."
         },
         "keywords": {
-          "const": ["Buildings", "Building height", "Elevation"]
+          "const": [
+            "Buildings",
+            "Building height",
+            "Elevation"
+          ]
         },
-        "license": { "const": "proprietary" },
+        "license": {
+          "const": "proprietary"
+        },
         "providers": {
           "const": [
             {
               "name": "Copernicus Land Monitoring Service",
               "description": "The Copernicus Land Monitoring Service provides geographical information on land cover and its changes, land use, ground motions, vegetation state, water cycle and Earth's surface energy variables to a broad range of users in Europe and across the World in the field of environmental terrestrial applications.",
-              "roles": ["licensor", "host"],
+              "roles": [
+                "licensor",
+                "host"
+              ],
               "url": "https://land.copernicus.eu"
             }
           ]
@@ -199,21 +253,37 @@
         "extent": {
           "const": {
             "spatial": {
-              "bbox": [[-22.13, 35.07, 33.48, 64.38]]
+              "bbox": [
+                [
+                  -22.13,
+                  35.07,
+                  33.48,
+                  64.38
+                ]
+              ]
             },
             "temporal": {
-              "interval": [["2012-01-01T00:00:00Z", null]]
+              "interval": [
+                [
+                  "2012-01-01T00:00:00Z",
+                  null
+                ]
+              ]
             }
           }
         },
         "summaries": {
           "type": "object",
-          "required": ["proj:epsg"],
+          "required": [
+            "proj:code"
+          ],
           "minProperties": 1,
           "maxProperties": 1,
           "properties": {
-            "proj:epsg": {
-              "const": [3035]
+            "proj:code": {
+              "const": [
+                "EPSG:3035"
+              ]
             }
           }
         },
@@ -224,7 +294,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "license" },
+                  "rel": {
+                    "const": "license"
+                  },
                   "href": {
                     "const": "https://land.copernicus.eu/en/data-policy"
                   }
@@ -235,7 +307,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "self" },
+                  "rel": {
+                    "const": "self"
+                  },
                   "href": {
                     "type": "string",
                     "pattern": ".json$"
@@ -247,7 +321,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "root" },
+                  "rel": {
+                    "const": "root"
+                  },
                   "href": {
                     "type": "string",
                     "pattern": ".json$"
@@ -259,7 +335,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "parent" },
+                  "rel": {
+                    "const": "parent"
+                  },
                   "href": {
                     "type": "string",
                     "pattern": ".json$"
@@ -271,7 +349,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "item" },
+                  "rel": {
+                    "const": "item"
+                  },
                   "href": {
                     "type": "string",
                     "pattern": ".json$"

--- a/schema/products/vpp.json
+++ b/schema/products/vpp.json
@@ -222,19 +222,13 @@
                 {
                   "name": "Copernicus Land Monitoring Service",
                   "description": "The Copernicus Land Monitoring Service provides geographical information on land cover and its changes, land use, ground motions, vegetation state, water cycle and Earth's surface energy variables to a broad range of users in Europe and across the World in the field of environmental terrestrial applications.",
-                  "roles": [
-                    "licensor",
-                    "host"
-                  ],
+                  "roles": ["licensor", "host"],
                   "url": "https://land.copernicus.eu"
                 },
                 {
                   "name": "VITO NV",
                   "description": "VITO is an independent Flemish research organisation in the area of cleantech and sustainable development.",
-                  "roles": [
-                    "processor",
-                    "producer"
-                  ],
+                  "roles": ["processor", "producer"],
                   "url": "https://vito.be"
                 }
               ]
@@ -264,10 +258,7 @@
               }
             },
             "proj:shape": {
-              "const": [
-                10980,
-                10980
-              ]
+              "const": [10980, 10980]
             }
           }
         },
@@ -396,19 +387,13 @@
             {
               "name": "Copernicus Land Monitoring Service",
               "description": "The Copernicus Land Monitoring Service provides geographical information on land cover and its changes, land use, ground motions, vegetation state, water cycle and Earth's surface energy variables to a broad range of users in Europe and across the World in the field of environmental terrestrial applications.",
-              "roles": [
-                "licensor",
-                "host"
-              ],
+              "roles": ["licensor", "host"],
               "url": "https://land.copernicus.eu"
             },
             {
               "name": "VITO NV",
               "description": "VITO is an independent Flemish research organisation in the area of cleantech and sustainable development.",
-              "roles": [
-                "processor",
-                "producer"
-              ],
+              "roles": ["processor", "producer"],
               "url": "https://vito.be"
             }
           ]
@@ -416,30 +401,16 @@
         "extent": {
           "const": {
             "spatial": {
-              "bbox": [
-                [
-                  -25,
-                  26,
-                  45,
-                  72
-                ]
-              ]
+              "bbox": [[-25, 26, 45, 72]]
             },
             "temporal": {
-              "interval": [
-                [
-                  "2017-01-01T00:00:00Z",
-                  null
-                ]
-              ]
+              "interval": [["2017-01-01T00:00:00Z", null]]
             }
           }
         },
         "summaries": {
           "type": "object",
-          "required": [
-            "proj:code"
-          ],
+          "required": ["proj:code"],
           "minProperties": 1,
           "maxProperties": 1,
           "properties": {

--- a/schema/products/vpp.json
+++ b/schema/products/vpp.json
@@ -19,13 +19,17 @@
         "assets"
       ],
       "properties": {
-        "stac_version": { "const": "1.0.0" },
+        "stac_version": {
+          "const": "1.1.0"
+        },
         "stac_extensions": {
           "const": [
-            "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+            "https://stac-extensions.github.io/projection/v2.0.0/schema.json"
           ]
         },
-        "type": { "const": "Feature" },
+        "type": {
+          "const": "Feature"
+        },
         "id": {
           "type": "string",
           "pattern": "^VPP"
@@ -37,50 +41,146 @@
           "oneOf": [
             {
               "items": [
-                { "type": "number", "minimum": -31.86, "maximum": 45.12 },
-                { "type": "number", "minimum": 26.99, "maximum": 72.09 },
-                { "type": "number", "minimum": -31.86, "maximum": 45.12 },
-                { "type": "number", "minimum": 26.99, "maximum": 72.09 }
+                {
+                  "type": "number",
+                  "minimum": -31.86,
+                  "maximum": 45.12
+                },
+                {
+                  "type": "number",
+                  "minimum": 26.99,
+                  "maximum": 72.09
+                },
+                {
+                  "type": "number",
+                  "minimum": -31.86,
+                  "maximum": 45.12
+                },
+                {
+                  "type": "number",
+                  "minimum": 26.99,
+                  "maximum": 72.09
+                }
               ]
             },
             {
               "items": [
-                { "type": "number", "minimum": -62.09, "maximum": -60.1 },
-                { "type": "number", "minimum": 13.45, "maximum": 15.38 },
-                { "type": "number", "minimum": -62.09, "maximum": -60.1 },
-                { "type": "number", "minimum": 13.45, "maximum": 15.38 }
+                {
+                  "type": "number",
+                  "minimum": -62.09,
+                  "maximum": -60.1
+                },
+                {
+                  "type": "number",
+                  "minimum": 13.45,
+                  "maximum": 15.38
+                },
+                {
+                  "type": "number",
+                  "minimum": -62.09,
+                  "maximum": -60.1
+                },
+                {
+                  "type": "number",
+                  "minimum": 13.45,
+                  "maximum": 15.38
+                }
               ]
             },
             {
               "items": [
-                { "type": "number", "minimum": 44.07, "maximum": 46.02 },
-                { "type": "number", "minimum": -13.67, "maximum": -11.75 },
-                { "type": "number", "minimum": 44.07, "maximum": 46.02 },
-                { "type": "number", "minimum": -13.67, "maximum": -11.75 }
+                {
+                  "type": "number",
+                  "minimum": 44.07,
+                  "maximum": 46.02
+                },
+                {
+                  "type": "number",
+                  "minimum": -13.67,
+                  "maximum": -11.75
+                },
+                {
+                  "type": "number",
+                  "minimum": 44.07,
+                  "maximum": 46.02
+                },
+                {
+                  "type": "number",
+                  "minimum": -13.67,
+                  "maximum": -11.75
+                }
               ]
             },
             {
               "items": [
-                { "type": "number", "minimum": 55.06, "maximum": 56.15 },
-                { "type": "number", "minimum": -21.8, "maximum": -19.88 },
-                { "type": "number", "minimum": 55.06, "maximum": 56.15 },
-                { "type": "number", "minimum": -21.8, "maximum": -19.88 }
+                {
+                  "type": "number",
+                  "minimum": 55.06,
+                  "maximum": 56.15
+                },
+                {
+                  "type": "number",
+                  "minimum": -21.8,
+                  "maximum": -19.88
+                },
+                {
+                  "type": "number",
+                  "minimum": 55.06,
+                  "maximum": 56.15
+                },
+                {
+                  "type": "number",
+                  "minimum": -21.8,
+                  "maximum": -19.88
+                }
               ]
             },
             {
               "items": [
-                { "type": "number", "minimum": -62.08, "maximum": -60.08 },
-                { "type": "number", "minimum": 15.26, "maximum": 17.19 },
-                { "type": "number", "minimum": -62.08, "maximum": -60.08 },
-                { "type": "number", "minimum": 15.26, "maximum": 17.19 }
+                {
+                  "type": "number",
+                  "minimum": -62.08,
+                  "maximum": -60.08
+                },
+                {
+                  "type": "number",
+                  "minimum": 15.26,
+                  "maximum": 17.19
+                },
+                {
+                  "type": "number",
+                  "minimum": -62.08,
+                  "maximum": -60.08
+                },
+                {
+                  "type": "number",
+                  "minimum": 15.26,
+                  "maximum": 17.19
+                }
               ]
             },
             {
               "items": [
-                { "type": "number", "minimum": -55.21, "maximum": -50.9 },
-                { "type": "number", "minimum": 1.71, "maximum": 6.34 },
-                { "type": "number", "minimum": -55.21, "maximum": -50.9 },
-                { "type": "number", "minimum": 1.71, "maximum": 6.34 }
+                {
+                  "type": "number",
+                  "minimum": -55.21,
+                  "maximum": -50.9
+                },
+                {
+                  "type": "number",
+                  "minimum": 1.71,
+                  "maximum": 6.34
+                },
+                {
+                  "type": "number",
+                  "minimum": -55.21,
+                  "maximum": -50.9
+                },
+                {
+                  "type": "number",
+                  "minimum": 1.71,
+                  "maximum": 6.34
+                }
               ]
             }
           ]
@@ -94,13 +194,17 @@
             "end_datetime",
             "created",
             "providers",
-            "proj:epsg",
+            "proj:code",
             "proj:bbox",
             "proj:shape"
           ],
           "properties": {
-            "description": { "type": "string" },
-            "datetime": { "const": null },
+            "description": {
+              "type": "string"
+            },
+            "datetime": {
+              "const": null
+            },
             "start_datetime": {
               "type": "string",
               "pattern": "20(1[7-9]|[2-9][0-9])-01-01T(0[0-9]|1[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])(\\.[0-9]{3})?Z"
@@ -118,24 +222,39 @@
                 {
                   "name": "Copernicus Land Monitoring Service",
                   "description": "The Copernicus Land Monitoring Service provides geographical information on land cover and its changes, land use, ground motions, vegetation state, water cycle and Earth's surface energy variables to a broad range of users in Europe and across the World in the field of environmental terrestrial applications.",
-                  "roles": ["licensor", "host"],
+                  "roles": [
+                    "licensor",
+                    "host"
+                  ],
                   "url": "https://land.copernicus.eu"
                 },
                 {
                   "name": "VITO NV",
                   "description": "VITO is an independent Flemish research organisation in the area of cleantech and sustainable development.",
-                  "roles": ["processor", "producer"],
+                  "roles": [
+                    "processor",
+                    "producer"
+                  ],
                   "url": "https://vito.be"
                 }
               ]
             },
-            "proj:epsg": {
-              "type": "integer",
-              "oneOf": [
-                { "minimum": 32620, "maximum": 32622 },
-                { "minimum": 32625, "maximum": 32638 },
-                { "minimum": 32738, "maximum": 32738 },
-                { "minimum": 32740, "maximum": 32740 }
+            "proj:code": {
+              "type": "string",
+              "enum": [
+                "EPSG:32620",
+                "EPSG:32621",
+                "EPSG:32622",
+                "EPSG:32625",
+                "EPSG:32626",
+                "EPSG:32627",
+                "EPSG:32628",
+                "EPSG:32629",
+                "EPSG:32630",
+                "EPSG:32631",
+                "EPSG:32632",
+                "EPSG:32633",
+                "EPSG:32634"
               ]
             },
             "proj:bbox": {
@@ -145,11 +264,16 @@
               }
             },
             "proj:shape": {
-              "const": [10980, 10980]
+              "const": [
+                10980,
+                10980
+              ]
             }
           }
         },
-        "collection": { "const": "vegetation-phenology-and-productivity" },
+        "collection": {
+          "const": "vegetation-phenology-and-productivity"
+        },
         "links": {
           "type": "array",
           "allOf": [
@@ -165,7 +289,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "self" }
+                  "rel": {
+                    "const": "self"
+                  }
                 }
               }
             },
@@ -173,7 +299,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "root" }
+                  "rel": {
+                    "const": "root"
+                  }
                 }
               }
             },
@@ -181,7 +309,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "parent" }
+                  "rel": {
+                    "const": "parent"
+                  }
                 }
               }
             },
@@ -189,7 +319,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "collection" }
+                  "rel": {
+                    "const": "collection"
+                  }
                 }
               }
             }
@@ -224,15 +356,21 @@
         "item_assets"
       ],
       "properties": {
-        "stac_version": { "const": "1.0.0" },
+        "stac_version": {
+          "const": "1.1.0"
+        },
         "stac_extensions": {
           "const": [
-            "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
+            "https://stac-extensions.github.io/projection/v2.0.0/schema.json",
             "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
           ]
         },
-        "type": { "const": "Collection" },
-        "id": { "const": "vegetation-phenology-and-productivity" },
+        "type": {
+          "const": "Collection"
+        },
+        "id": {
+          "const": "vegetation-phenology-and-productivity"
+        },
         "title": {
           "const": "Vegetation Phenology and Productivity Parameters"
         },
@@ -250,19 +388,27 @@
             "vegetation"
           ]
         },
-        "license": { "const": "proprietary" },
+        "license": {
+          "const": "proprietary"
+        },
         "providers": {
           "const": [
             {
               "name": "Copernicus Land Monitoring Service",
               "description": "The Copernicus Land Monitoring Service provides geographical information on land cover and its changes, land use, ground motions, vegetation state, water cycle and Earth's surface energy variables to a broad range of users in Europe and across the World in the field of environmental terrestrial applications.",
-              "roles": ["licensor", "host"],
+              "roles": [
+                "licensor",
+                "host"
+              ],
               "url": "https://land.copernicus.eu"
             },
             {
               "name": "VITO NV",
               "description": "VITO is an independent Flemish research organisation in the area of cleantech and sustainable development.",
-              "roles": ["processor", "producer"],
+              "roles": [
+                "processor",
+                "producer"
+              ],
               "url": "https://vito.be"
             }
           ]
@@ -270,24 +416,48 @@
         "extent": {
           "const": {
             "spatial": {
-              "bbox": [[-25, 26, 45, 72]]
+              "bbox": [
+                [
+                  -25,
+                  26,
+                  45,
+                  72
+                ]
+              ]
             },
             "temporal": {
-              "interval": [["2017-01-01T00:00:00Z", null]]
+              "interval": [
+                [
+                  "2017-01-01T00:00:00Z",
+                  null
+                ]
+              ]
             }
           }
         },
         "summaries": {
           "type": "object",
-          "required": ["proj:epsg"],
+          "required": [
+            "proj:code"
+          ],
           "minProperties": 1,
           "maxProperties": 1,
           "properties": {
-            "proj:epsg": {
+            "proj:code": {
               "const": [
-                32620, 32621, 32622, 32625, 32626, 32627, 32628, 32629, 32630,
-                32631, 32632, 32633, 32634, 32635, 32636, 32637, 32638, 32738,
-                32740
+                "EPSG:32620",
+                "EPSG:32621",
+                "EPSG:32622",
+                "EPSG:32625",
+                "EPSG:32626",
+                "EPSG:32627",
+                "EPSG:32628",
+                "EPSG:32629",
+                "EPSG:32630",
+                "EPSG:32631",
+                "EPSG:32632",
+                "EPSG:32633",
+                "EPSG:32634"
               ]
             }
           }
@@ -299,7 +469,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "license" },
+                  "rel": {
+                    "const": "license"
+                  },
                   "href": {
                     "const": "https://land.copernicus.eu/en/data-policy"
                   }
@@ -310,7 +482,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "self" },
+                  "rel": {
+                    "const": "self"
+                  },
                   "href": {
                     "type": "string",
                     "pattern": ".json$"
@@ -322,7 +496,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "root" },
+                  "rel": {
+                    "const": "root"
+                  },
                   "href": {
                     "type": "string",
                     "pattern": ".json$"
@@ -334,7 +510,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "parent" },
+                  "rel": {
+                    "const": "parent"
+                  },
                   "href": {
                     "type": "string",
                     "pattern": ".json$"
@@ -346,7 +524,9 @@
               "contains": {
                 "type": "object",
                 "properties": {
-                  "rel": { "const": "item" },
+                  "rel": {
+                    "const": "item"
+                  },
                   "href": {
                     "type": "string",
                     "pattern": ".json$"

--- a/scripts/clc/collection.py
+++ b/scripts/clc/collection.py
@@ -164,7 +164,7 @@ def populate_collection(collection: pystac.Collection, data_root: str) -> pystac
     collection.make_all_asset_hrefs_relative()
     collection.update_extent_from_items()
     ProjectionExtension.add_to(collection)
-    collection.summaries = pystac.Summaries({"proj:epsg": list(set(proj_epsg))})
+    collection.summaries = pystac.Summaries({"proj:code": list(set(proj_epsg))})
 
     try:
         error_msg = best_match(validator.iter_errors(collection.to_dict()))

--- a/scripts/clc/item.py
+++ b/scripts/clc/item.py
@@ -192,7 +192,7 @@ def create_item(img_path: str, data_root: str) -> pystac.Item:
 
     proj_ext = ProjectionExtension.ext(item.assets[os.path.basename(img_path).replace(".", "_")], add_if_missing=True)
     proj_ext.apply(
-        epsg=rio.crs.CRS(img.crs).to_epsg(),
+        code=rio.crs.CRS(img.crs).to_epsg(),
         bbox=img.bounds,
         shape=list(img.shape),
         transform=[*list(img.transform), 0.0, 0.0, 1.0],

--- a/scripts/euhydro/collection.py
+++ b/scripts/euhydro/collection.py
@@ -75,7 +75,7 @@ def create_asset(filename, asset_path):
     )
 
 
-def collect_assets(root: str) -> list[str]:
+def collect_assets(root: str) -> dict[str, pystac.Asset]:
     asset_list = get_files(root, "xml") + get_files(root, "pdf") + get_files(root, "gpkg") + get_gdb(root)
     assets = {}
     for asset_path in asset_list:
@@ -127,6 +127,8 @@ def create_collection(euhydro_root: str) -> pystac.Collection:
         # update links
         collection.set_self_href(os.path.join(WORKING_DIR, f"{STAC_DIR}/{COLLECTION_ID}/{collection.id}.json"))
         catalog = pystac.read_file(f"{WORKING_DIR}/{STAC_DIR}/clms_catalog.json")
+        if not isinstance(catalog, pystac.Catalog):
+            raise CollectionCreationError("Root object is not a pystac.Catalog")
         collection.set_root(catalog)
         collection.set_parent(catalog)
     except Exception as error:

--- a/scripts/euhydro/collection.py
+++ b/scripts/euhydro/collection.py
@@ -86,9 +86,9 @@ def collect_assets(root: str) -> list[str]:
     return assets
 
 
-def add_summaries_to_collection(collection: pystac.Collection, epsg_list: list[int]) -> None:
+def add_summaries_to_collection(collection: pystac.Collection, epsg_list: list[str]) -> None:
     summaries = ProjectionExtension.summaries(collection, add_if_missing=True)
-    summaries.epsg = epsg_list
+    summaries.code = epsg_list
 
 
 def add_links_to_collection(collection: pystac.Collection, link_list: list[pystac.Link]) -> None:
@@ -113,7 +113,7 @@ def create_collection(euhydro_root: str) -> pystac.Collection:
         )
 
         # summaries
-        epsg_list = [3035]
+        epsg_list = ["EPSG:3035"]
         add_summaries_to_collection(collection, epsg_list)
 
         # links

--- a/scripts/n2k/collection.py
+++ b/scripts/n2k/collection.py
@@ -91,7 +91,7 @@ def create_asset(filename, asset_path):
     )
 
 
-def collect_assets(n2k_root: str) -> list[str]:
+def collect_assets(n2k_root: str) -> dict[str, pystac.Asset]:
     asset_list = (
         get_files(n2k_root, "xml")
         + get_files(n2k_root, "lyr")
@@ -151,6 +151,8 @@ def create_collection(n2k_root: str) -> pystac.Collection:
         # update links
         collection.set_self_href(os.path.join(WORKING_DIR, f"{STAC_DIR}/{COLLECTION_ID}/{collection.id}.json"))
         catalog = pystac.read_file(f"{WORKING_DIR}/{STAC_DIR}/clms_catalog.json")
+        if not isinstance(catalog, pystac.Catalog):
+            raise CollectionCreationError("Parent catalog is not a pystac.Catalog instance.")
         collection.set_root(catalog)
         collection.set_parent(catalog)
     except Exception as error:

--- a/scripts/n2k/collection.py
+++ b/scripts/n2k/collection.py
@@ -110,9 +110,9 @@ def collect_assets(n2k_root: str) -> list[str]:
     return assets
 
 
-def add_summaries_to_collection(collection: pystac.Collection, epsg_list: list[int]) -> None:
+def add_summaries_to_collection(collection: pystac.Collection, epsg_list: list[str]) -> None:
     summaries = ProjectionExtension.summaries(collection, add_if_missing=True)
-    summaries.epsg = epsg_list
+    summaries.code = epsg_list
 
 
 def add_links_to_collection(collection: pystac.Collection, link_list: list[pystac.Link]) -> None:
@@ -137,7 +137,7 @@ def create_collection(n2k_root: str) -> pystac.Collection:
         )
 
         # summaries
-        epsg_list = [3035]
+        epsg_list = ["EPSG:3035"]
         add_summaries_to_collection(collection, epsg_list)
 
         # links

--- a/scripts/uabh/collection.py
+++ b/scripts/uabh/collection.py
@@ -84,9 +84,9 @@ def create_core_collection() -> pystac.Collection:
     )
 
 
-def add_summaries_to_collection(collection: pystac.Collection, epsg_list: list[int]) -> None:
+def add_summaries_to_collection(collection: pystac.Collection, epsg_list: list[str]) -> None:
     summaries = ProjectionExtension.summaries(collection, add_if_missing=True)
-    summaries.epsg = epsg_list
+    summaries.code = epsg_list
 
 
 def add_item_assets_to_collection(collection: pystac.Collection, item_asset_class: Enum) -> None:
@@ -110,7 +110,7 @@ def create_collection(item_list: list[str]) -> None:
         collection = create_core_collection()
 
         # summaries
-        epsg_list = [3035]
+        epsg_list = ["EPSG:3035"]
         add_summaries_to_collection(collection, epsg_list)
 
         # extensions

--- a/scripts/uabh/item.py
+++ b/scripts/uabh/item.py
@@ -203,7 +203,7 @@ def add_providers_to_item(item: pystac.Item, provider_list: list[pystac.Provider
 
 def add_projection_extension_to_item(item: pystac.Item, crs: CRS, bounds: BoundingBox, height: int, width: int) -> None:
     projection = ProjectionExtension.ext(item, add_if_missing=True)
-    projection.epsg = crs.to_epsg()
+    projection.code = crs.to_epsg()
     projection.bbox = [int(bounds.left), int(bounds.bottom), int(bounds.right), int(bounds.top)]
     projection.shape = [height, width]
 

--- a/scripts/uabh/item.py
+++ b/scripts/uabh/item.py
@@ -54,7 +54,10 @@ def str_to_datetime(datetime_str: str):
 
 
 def get_namespace(tag: str, xml_string: str) -> str:
-    return re.search(r"xmlns:" + tag + '="([^"]+)"', xml_string).group(0).split("=")[1][1:-1]
+    match = re.search(r"xmlns:" + tag + '="([^"]+)"', xml_string)
+    if not match:
+        raise ValueError(f'Namespace for tag "{tag}" not found in XML string.')
+    return match.group(0).split("=")[1][1:-1]
 
 
 def get_metadata_from_xml(xml: str) -> tuple[datetime, datetime, datetime]:
@@ -64,26 +67,24 @@ def get_metadata_from_xml(xml: str) -> tuple[datetime, datetime, datetime]:
     gml_namespace = get_namespace("gml", xml_string)
     tree = ETree.parse(xml)
     root = tree.getroot()
-    start_datetime = root.findall("".join((".//{", gml_namespace, "}beginPosition")))[0].text  # noqa: FLY002
-    end_datetime = root.findall("".join((".//{", gml_namespace, "}endPosition")))[0].text  # noqa: FLY002
-    created = root.findall(
-        "".join(  # noqa: FLY002
-            (
-                ".//{",
-                gmd_namespace,
-                "}CI_DateTypeCode[@codeListValue='creation']....//{",
-                gmd_namespace,
-                "}date/*",
-            )
-        )
-    )[0].text
-    return (str_to_datetime(start_datetime), str_to_datetime(end_datetime), str_to_datetime(created))
+    start_elem = root.findall(f".//{{{gml_namespace}}}beginPosition")[0]
+    end_elem = root.findall(f".//{{{gml_namespace}}}endPosition")[0]
+    created_elem = root.findall(
+        f".//{{{gmd_namespace}}}CI_DateTypeCode[@codeListValue='creation']....//{{{gmd_namespace}}}date/*"
+    )[0]
+
+    if start_elem.text is None or end_elem.text is None or created_elem.text is None:
+        raise ValueError("One or more required date fields are missing in the XML.")
+
+    return (
+        str_to_datetime(start_elem.text),
+        str_to_datetime(end_elem.text),
+        str_to_datetime(created_elem.text),
+    )
 
 
 def get_geom_wgs84(bounds: BoundingBox, crs: CRS) -> Polygon:
-    bbox = rio.coords.BoundingBox(
-        *transform_bounds(crs.to_epsg(), 4326, bounds.left, bounds.bottom, bounds.right, bounds.top)
-    )
+    bbox = BoundingBox(*transform_bounds(crs.to_epsg(), 4326, bounds.left, bounds.bottom, bounds.right, bounds.top))
     return box(*(bbox.left, bbox.bottom, bbox.right, bbox.top))
 
 
@@ -103,7 +104,7 @@ def get_files(uabh_root: str, city_code: str, asset_type: str) -> list[str]:
     return files
 
 
-def get_zip(uabh_root: str, city_code: str) -> str:
+def get_zip(uabh_root: str, city_code: str) -> list[str]:
     files = []
     for dirpath, _, filenames in os.walk(uabh_root):
         files += [
@@ -121,7 +122,7 @@ def collect_assets(uabh_root: str, city_code: str) -> dict[str, pystac.Asset]:
         + get_files(uabh_root, city_code, "Metadata")
         + get_files(uabh_root, city_code, "PixelBasedInfo")
         + get_files(uabh_root, city_code, "QC")
-        + get_zip(uabh_root, city_code)
+        + list(get_zip(uabh_root, city_code))
     )
     assets = {}
     for asset_path in asset_list:

--- a/scripts/vpp/collection.py
+++ b/scripts/vpp/collection.py
@@ -55,9 +55,9 @@ def create_core_collection() -> pystac.Collection:
     )
 
 
-def add_summaries_to_collection(collection: pystac.Collection, epsg_list: list[int]) -> None:
+def add_summaries_to_collection(collection: pystac.Collection, epsg_list: list[str]) -> None:
     summaries = ProjectionExtension.summaries(collection, add_if_missing=True)
-    summaries.epsg = epsg_list
+    summaries.code = epsg_list
 
 
 def add_item_assets_to_collection(collection: pystac.Collection, asset_title_map: dict[str, str]) -> None:
@@ -85,25 +85,19 @@ def create_collection(item_list: list[str]) -> pystac.Collection:
 
         # summaries
         epsg_list = [
-            32620,
-            32621,
-            32622,
-            32625,
-            32626,
-            32627,
-            32628,
-            32629,
-            32630,
-            32631,
-            32632,
-            32633,
-            32634,
-            32635,
-            32636,
-            32637,
-            32638,
-            32738,
-            32740,
+            "EPSG:32620",
+            "EPSG:32621",
+            "EPSG:32622",
+            "EPSG:32625",
+            "EPSG:32626",
+            "EPSG:32627",
+            "EPSG:32628",
+            "EPSG:32629",
+            "EPSG:32630",
+            "EPSG:32631",
+            "EPSG:32632",
+            "EPSG:32633",
+            "EPSG:32634",
         ]
         add_summaries_to_collection(collection, epsg_list)
 

--- a/scripts/vpp/collection.py
+++ b/scripts/vpp/collection.py
@@ -76,6 +76,8 @@ def add_links_to_collection(collection: pystac.Collection, link_list: list[Link]
 def add_items_to_collection(collection: pystac.Collection, item_list: list[str]) -> None:
     for item in item_list:
         stac_object = pystac.read_file(item)
+        if not isinstance(stac_object, pystac.Item):
+            raise TypeError(f"Object loaded from {item} is not a pystac.Item")
         collection.add_item(stac_object, title=stac_object.id)
 
 
@@ -113,9 +115,11 @@ def create_collection(item_list: list[str]) -> pystac.Collection:
 
         # add self, root, and parent links
         collection.set_self_href(os.path.join(WORKING_DIR, f"{STAC_DIR}/{collection.id}/{collection.id}.json"))
-        catalog = pystac.read_file(f"{WORKING_DIR}/{STAC_DIR}/clms_catalog.json")
-        collection.set_root(catalog)
-        collection.set_parent(catalog)
+        catalog_obj = pystac.read_file(f"{WORKING_DIR}/{STAC_DIR}/clms_catalog.json")
+        if not isinstance(catalog_obj, pystac.Catalog):
+            raise TypeError("Object loaded from catalog file is not a pystac.Catalog")
+        collection.set_root(catalog_obj)
+        collection.set_parent(catalog_obj)
     except Exception as error:
         raise CollectionCreationError(error)
     return collection

--- a/scripts/vpp/item.py
+++ b/scripts/vpp/item.py
@@ -126,7 +126,7 @@ def add_providers_to_item(item: pystac.Item, provider_list: list[pystac.Provider
 
 def add_projection_extension_to_item(item: pystac.Item, crs: CRS, bounds: BoundingBox, height: int, width: int) -> None:
     projection = ProjectionExtension.ext(item, add_if_missing=True)
-    projection.epsg = crs.to_epsg()
+    projection.code = crs.to_epsg()
     projection.bbox = [int(bounds.left), int(bounds.bottom), int(bounds.right), int(bounds.top)]
     projection.shape = [height, width]
 

--- a/scripts/vpp/item.py
+++ b/scripts/vpp/item.py
@@ -54,22 +54,22 @@ def create_page_iterator(aws_session: boto3.Session, bucket: str, prefix: str) -
     return paginator.paginate(Bucket=bucket, Prefix=prefix, Delimiter="-")
 
 
-def read_metadata_from_s3(bucket: str, key: str, aws_session: boto3.Session) -> tuple[BoundingBox, CRS, int, int]:
-    s3 = aws_session.resource("s3")
-    obj = s3.Object(bucket, key)
-    body = obj.get()["Body"].read()
+def read_metadata_from_s3(
+    bucket: str, key: str, aws_session: boto3.Session
+) -> tuple[BoundingBox, CRS, int, int, datetime]:
+    client = aws_session.client("s3")
+    obj = client.get_object(Bucket=bucket, Key=key)
+    body = obj["Body"].read()
     with rio.open(io.BytesIO(body)) as tif:
         bounds = tif.bounds
         crs = tif.crs
         height = tif.height
         width = tif.width
-    return (bounds, crs, height, width, obj.last_modified)
+    return (bounds, crs, height, width, obj["LastModified"])
 
 
 def get_geom_wgs84(bounds: BoundingBox, crs: CRS) -> Polygon:
-    bbox = rio.coords.BoundingBox(
-        *transform_bounds(crs.to_epsg(), 4326, bounds.left, bounds.bottom, bounds.right, bounds.top)
-    )
+    bbox = BoundingBox(*transform_bounds(crs.to_epsg(), 4326, bounds.left, bounds.bottom, bounds.right, bounds.top))
     return box(*(bbox.left, bbox.bottom, bbox.right, bbox.top))
 
 


### PR DESCRIPTION
This PR migrates the Vegetation Phenology and Productivity (VPP) STAC Collection and related components to STAC 1.1.0, aligning with the latest specification and schema constraints. It includes file updates, schema migration, structural refactoring, and infrastructure adjustments.

- [x] Create updated version of current STAC files using STAC 1.1.0
- [x] Upgrade schema from STAC 1.0.0 → 1.1.0 using stactools migrate
- [x] Refactor item_assets import structure — now part of core STAC spec, no longer extension
- [ ] Validate updated STAC files against custom JSON Schema (vpp.json)
- [ ] Update S3 bucket paths to reflect new routing for STAC 1.1.0 content